### PR TITLE
Bump sbcidentify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.2
 
 require (
 	github.com/elliotchance/orderedmap/v3 v3.1.0
-	github.com/rinzlerlabs/sbcidentify v0.1.2
+	github.com/rinzlerlabs/sbcidentify v0.1.4
 	github.com/shirou/gopsutil/v4 v4.24.11
 	github.com/stretchr/testify v1.9.0
 	github.com/thegreatco/viamutils v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
-github.com/NVIDIA/go-nvml v0.12.4-1 h1:WKUvqshhWSNTfm47ETRhv0A0zJyr1ncCuHiXwoTrBEc=
-github.com/NVIDIA/go-nvml v0.12.4-1/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -924,8 +922,8 @@ github.com/quasilyte/go-ruleguard/rules v0.0.0-20210203162857-b223e0831f88/go.mo
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20210221215616-dfcc94e3dffd/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/rinzlerlabs/sbcidentify v0.1.2 h1:Z9H0msJhzwHYBWcXxLnnPFL/QMrwfr23x3JAt6VmUWI=
-github.com/rinzlerlabs/sbcidentify v0.1.2/go.mod h1:ud+PH8+YnavAPHJNqaWgfhNouQmEYCs3wMN4OKGN6UM=
+github.com/rinzlerlabs/sbcidentify v0.1.4 h1:HG6GRzdSttu6/X25T0rWVODakF0UHMPJ13YKqPjnWw4=
+github.com/rinzlerlabs/sbcidentify v0.1.4/go.mod h1:ud+PH8+YnavAPHJNqaWgfhNouQmEYCs3wMN4OKGN6UM=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
- Bump sbcidentify to 0.1.4
- go mod tidy

I tried to bump the viam go module dependencies, but there have been substantial changes to the prototypes.  It would be a bunch of work to bring this module up to current releases of the viam go modules.

The bump to sbcidentify is the minimum required change.